### PR TITLE
feat(nixos): add git trust for all dirs

### DIFF
--- a/nixos/Dockerfile
+++ b/nixos/Dockerfile
@@ -1,3 +1,6 @@
 FROM nixos/nix:2.20.5
 
+# Enable flakes
 RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
+# Trust all directory to run flake commands as root on different volumes
+RUN git config --global --add safe.directory '*'


### PR DESCRIPTION
This make it possible to run commands nix flake commands to all directories without errors, even mounted volumes with different permissions since we run as root.