### PR TITLE
feat(nixos): enable builders-use-substitutes

### DIFF
--- a/nixos/Dockerfile
+++ b/nixos/Dockerfile
@@ -2,5 +2,8 @@ FROM nixos/nix:2.20.5
 
 # Enable flakes
 RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
+# Enable remote builders substitures
+# https://nix.dev/manual/nix/2.18/command-ref/conf-file.html?highlight=builders-use-substitutes#conf-builders-use-substitutes
+RUN echo "builders-use-substitutes = true" >> /etc/nix/nix.conf
 # Trust all directory to run flake commands as root on different volumes
 RUN git config --global --add safe.directory '*'


### PR DESCRIPTION
This will use the builders local cache instead of asking the client to upload it's own.